### PR TITLE
Make instance property and makeObservable() method protected

### DIFF
--- a/lib/http.service.ts
+++ b/lib/http.service.ts
@@ -12,7 +12,7 @@ import { AXIOS_INSTANCE_TOKEN } from './http.constants';
 export class HttpService {
   constructor(
     @Inject(AXIOS_INSTANCE_TOKEN)
-    private readonly instance: AxiosInstance = Axios,
+    protected readonly instance: AxiosInstance = Axios,
   ) {}
 
   request<T = any>(config: AxiosRequestConfig): Observable<AxiosResponse<T>> {
@@ -68,7 +68,7 @@ export class HttpService {
     return this.instance;
   }
 
-  private makeObservable<T>(
+  protected makeObservable<T>(
     axios: (...args: any[]) => AxiosPromise<T>,
     ...args: any[]
   ) {


### PR DESCRIPTION
Make `instance` property and `makeObservable()` method `protected` instead of `private`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently `instance` and `makeObservable()` are marked `private` this makes it difficult to subclass the `HttpService` and add additional functionality. 

Issue Number: N/A


## What is the new behavior?
`instance` and `makeObservable()` are marked as `protected` so subclasses can utilize.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
