### PR TITLE
feat: expose HttpErrorResponse type

### DIFF
--- a/lib/interfaces/http-module.interface.ts
+++ b/lib/interfaces/http-module.interface.ts
@@ -1,7 +1,9 @@
 import { ModuleMetadata, Provider, Type } from '@nestjs/common';
-import { AxiosRequestConfig } from 'axios';
+import { AxiosError, AxiosRequestConfig } from 'axios';
 
 export type HttpModuleOptions = AxiosRequestConfig;
+
+export type HttpResponseError = AxiosError;
 
 export interface HttpModuleOptionsFactory {
   createHttpOptions(): Promise<HttpModuleOptions> | HttpModuleOptions;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
It is not possible to have a typed variable for http errors.

Issue Number: N/A


## What is the new behavior?
A new type is exposed for http error handling. This is useful when you catch the error using the `catchError` rxjs operator.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No