### PR TITLE
refactor(axios): export axios types

### DIFF
--- a/lib/axios.types.ts
+++ b/lib/axios.types.ts
@@ -1,0 +1,7 @@
+export {
+  AxiosInstance,
+  AxiosPromise,
+  AxiosRequestConfig,
+  AxiosResponse,
+  CancelTokenSource,
+} from 'axios';

--- a/lib/axios.types.ts
+++ b/lib/axios.types.ts
@@ -4,4 +4,5 @@ export {
   AxiosRequestConfig,
   AxiosResponse,
   CancelTokenSource,
+  AxiosError,
 } from 'axios';

--- a/lib/http.service.ts
+++ b/lib/http.service.ts
@@ -1,11 +1,12 @@
 import { Inject } from '@nestjs/common';
-import Axios, {
+import {
   AxiosInstance,
   AxiosPromise,
   AxiosRequestConfig,
   AxiosResponse,
   CancelTokenSource,
-} from 'axios';
+} from './axios.types';
+import Axios from 'axios';
 import { Observable } from 'rxjs';
 import { AXIOS_INSTANCE_TOKEN } from './http.constants';
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,4 @@
 export * from './http.module';
 export * from './http.service';
 export * from './interfaces';
+export * from './axios.types';


### PR DESCRIPTION
resolves #639

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #639 

Currently, to have axios types in the NestJS application, we should add axios as a dependency, which can lead to a mismatched version between the 2 libraries.


## What is the new behavior?

It has exported the useful axios types to resolve the explained issue.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
