### PR TITLE
fix: all prettier configs have been merged into one

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,8 +8,7 @@ module.exports = {
   extends: [
     'plugin:@typescript-eslint/eslint-recommended',
     'plugin:@typescript-eslint/recommended',
-    'prettier',
-    'prettier/@typescript-eslint',
+    'prettier'
   ],
   root: true,
   env: {


### PR DESCRIPTION
"prettier/@typescript-eslint" has been merged into "prettier" as of version 8 (https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21).