### PR TITLE
Autofix: In POST request data type is now mandatory when it was not before.

### DIFF
--- a/lib/http.service.ts
+++ b/lib/http.service.ts
@@ -42,40 +42,25 @@ export class HttpService {
 
   post<T = any, D = any>(
     url: string,
-    data: D,
+    data?: D,
     config?: AxiosRequestConfig<D>,
-  ): Observable<AxiosResponse<T, D>>;
-  post<T = any>(
-    url: string,
-    data?: any,
-    config?: AxiosRequestConfig,
-  ): Observable<AxiosResponse<T>> {
+  ): Observable<AxiosResponse<T, D>> {
     return this.makeObservable<T>(this.instance.post, url, data, config);
   }
 
   put<T = any, D = any>(
     url: string,
-    data: D,
+    data?: D,
     config?: AxiosRequestConfig<D>,
-  ): Observable<AxiosResponse<T, D>>;
-  put<T = any>(
-    url: string,
-    data?: any,
-    config?: AxiosRequestConfig,
-  ): Observable<AxiosResponse<T>> {
+  ): Observable<AxiosResponse<T, D>> {
     return this.makeObservable<T>(this.instance.put, url, data, config);
   }
 
   patch<T = any, D = any>(
     url: string,
-    data: D,
+    data?: D,
     config?: AxiosRequestConfig<D>,
-  ): Observable<AxiosResponse<T, D>>;
-  patch<T = any>(
-    url: string,
-    data?: any,
-    config?: AxiosRequestConfig,
-  ): Observable<AxiosResponse<T>> {
+  ): Observable<AxiosResponse<T, D>> {
     return this.makeObservable<T>(this.instance.patch, url, data, config);
   }
 
@@ -83,12 +68,7 @@ export class HttpService {
     url: string,
     data: D,
     config?: AxiosRequestConfig<D>,
-  ): Observable<AxiosResponse<T, D>>;
-  postForm<T = any>(
-    url: string,
-    data?: any,
-    config?: AxiosRequestConfig,
-  ): Observable<AxiosResponse<T>> {
+  ): Observable<AxiosResponse<T, D>> {
     return this.makeObservable<T>(this.instance.postForm, url, data, config);
   }
 
@@ -96,12 +76,7 @@ export class HttpService {
     url: string,
     data: D,
     config?: AxiosRequestConfig<D>,
-  ): Observable<AxiosResponse<T, D>>;
-  putForm<T = any>(
-    url: string,
-    data?: any,
-    config?: AxiosRequestConfig,
-  ): Observable<AxiosResponse<T>> {
+  ): Observable<AxiosResponse<T, D>> {
     return this.makeObservable<T>(this.instance.putForm, url, data, config);
   }
 
@@ -109,12 +84,7 @@ export class HttpService {
     url: string,
     data: D,
     config?: AxiosRequestConfig<D>,
-  ): Observable<AxiosResponse<T, D>>;
-  patchForm<T = any>(
-    url: string,
-    data?: any,
-    config?: AxiosRequestConfig,
-  ): Observable<AxiosResponse<T>> {
+  ): Observable<AxiosResponse<T, D>> {
     return this.makeObservable<T>(this.instance.patchForm, url, data, config);
   }
 


### PR DESCRIPTION
I have identified the issue in the `HttpService` class where the `post` method's signature was changed, making the `data` parameter mandatory. This was indeed a breaking change. To fix this, I've updated the `post` method to maintain backwards compatibility by making the `data` parameter optional again. I've also applied the same fix to the `put` and `patch` methods for consistency. 
> [!CAUTION]  
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission